### PR TITLE
ci(workflows): replace scheduled playwright tests with random weekly trigger + update deps

### DIFF
--- a/.github/workflows/random-weekly-scheduler.yml
+++ b/.github/workflows/random-weekly-scheduler.yml
@@ -1,0 +1,45 @@
+name: Cypress Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    # Runs every day at 3 AM UTC
+    - cron: "0 3 * * *"
+
+jobs:
+  check-and-run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - name: Check if should run tests this week
+        id: should_run
+        run: |
+          # Get the week number of the year
+          WEEK_NUMBER=$(date +%V)
+          
+          # Get the day of the week (1=Monday, 7=Sunday)
+          DAY_OF_WEEK=$(date +%u)
+          
+          # Use week number as seed to generate a random day (1-7)
+          # This ensures the same day is chosen throughout the week
+          RANDOM_DAY=$((($WEEK_NUMBER % 7) + 1))
+          
+          echo "Week number: $WEEK_NUMBER"
+          echo "Current day: $DAY_OF_WEEK"
+          echo "Random day for this week: $RANDOM_DAY"
+          
+          # If current day matches the random day of the week
+          if [ "$DAY_OF_WEEK" -eq "$RANDOM_DAY" ]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "✅ Today is the chosen day for tests this week!"
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Not the chosen day for tests this week."
+          fi
+
+  trigger-tests:
+    needs: check-and-run
+    if: needs.check-and-run.outputs.should_run == 'true'
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test
 on:
   workflow_dispatch:
+  workflow_call:
   push:
-  schedule:
-    - cron: '0 1 * * 1-5'
 permissions:
   contents: read
   issues: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "ISC",
       "dependencies": {
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^24.3.1"
+        "@types/node": "^24.5.2"
       },
       "devDependencies": {
-        "cypress": "15.2.0",
+        "cypress": "15.3.0",
         "cypress-diff": "^0.0.6",
         "cypress-junit-reporter": "^1.3.1",
         "cypress-multi-reporters": "^2.0.5",
         "cypress-qase-reporter": "^3.0.3",
-        "eslint": "^9.35.0",
-        "fs-extra": "^11.3.1",
+        "eslint": "^9.36.0",
+        "fs-extra": "^11.3.2",
         "mocha": "^11.7.2",
         "typescript": "^5.9.2"
       }
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -408,12 +408,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -427,6 +427,13 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -861,15 +868,6 @@
         "node": "*"
       }
     },
-    "node_modules/check-more-types": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1070,9 +1068,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.2.0.tgz",
-      "integrity": "sha512-J4ehSzOSb58SkXyldCe9y/oZ8ep8Bl6+q9kDUjnkqNqc2ZKzDq5KSbhIc2lHFAFR5Jtj10oNqr9JRAZbr8DA8A==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.3.0.tgz",
+      "integrity": "sha512-g9rDhoK9y8wW4Vx3Ppr8dtfvThXxPL3mJsV5e98fG+6EerrhXKmeRT2sL86cvNRtEZouXJfsuVL1lqiMuGNGcg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1081,13 +1079,13 @@
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
+        "@types/tmp": "^0.2.3",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
         "ci-info": "^4.1.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "0.6.1",
@@ -1104,7 +1102,6 @@
         "fs-extra": "^9.1.0",
         "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
@@ -1126,7 +1123,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/cypress-diff": {
@@ -1511,9 +1508,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1523,7 +1520,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1969,9 +1966,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2585,15 +2582,6 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
       }
     },
     "node_modules/levn": {
@@ -3917,9 +3905,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
   },
   "homepage": "https://github.com/estefafdez/cypress-template#readme",
   "devDependencies": {
-    "cypress": "15.2.0",
+    "cypress": "15.3.0",
     "cypress-diff": "^0.0.6",
     "cypress-junit-reporter": "^1.3.1",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-qase-reporter": "^3.0.3",
-    "eslint": "^9.35.0",
-    "fs-extra": "^11.3.1",
+    "eslint": "^9.36.0",
+    "fs-extra": "^11.3.2",
     "mocha": "^11.7.2",
     "typescript": "^5.9.2"
   },
   "dependencies": {
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^24.3.1"
+    "@types/node": "^24.5.2"
   }
 }


### PR DESCRIPTION
This pull request introduces a new workflow for running Cypress tests on a randomized day each week, updates the test workflow to support reusable calls, and upgrades several development dependencies for improved stability and features.